### PR TITLE
#4 Ensure that deployments always have a target state of running.

### DIFF
--- a/vvp-magics/vvpmagics/deployments.py
+++ b/vvp-magics/vvpmagics/deployments.py
@@ -64,6 +64,7 @@ class Deployments:
             },
             "spec": {
                 "deploymentTargetId": target,
+                "state": "RUNNING",
                 "template": {
                     "spec": {
                         "artifact": {


### PR DESCRIPTION
- Include a target deployment state to ensure that deployments start, irrespective of any defaults set in the backend.