### PR TITLE
#20 Use explicit reference to getpass

### DIFF
--- a/vvp-magics/vvpmagics/vvpmagics.py
+++ b/vvp-magics/vvpmagics/vvpmagics.py
@@ -1,4 +1,4 @@
-from getpass import getpass
+import getpass
 
 from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic)
 from IPython.core.magic_arguments import magic_arguments, argument, parse_argstring
@@ -72,7 +72,7 @@ class VvpMagics(Magics):
 
     @staticmethod
     def get_api_key_interactively():
-        return getpass(prompt="API Key:")
+        return getpass.getpass(prompt="API Key:")
 
     @cell_magic
     @magic_arguments()


### PR DESCRIPTION
When using custom kernels the definition of this function can be overwritten.
This explicit reference fixes this.
[https://github.com/ipython/ipykernel/issues/308](https://github.com/ipython/ipykernel/issues/308)